### PR TITLE
Fixed Key Error with channel name

### DIFF
--- a/twitchkeywords/TwitchKeyword.py
+++ b/twitchkeywords/TwitchKeyword.py
@@ -47,7 +47,7 @@ class Keyword(commands.Bot):
                 client_id=client,
                 nick=channel_name,
                 prefix='!',
-                initial_channels=[f"#channel_name"],
+                initial_channels=[f"#{channel_name}"],
         )
 
         self._keywords = dict()

--- a/twitchkeywords/TwitchKeyword.py
+++ b/twitchkeywords/TwitchKeyword.py
@@ -47,7 +47,7 @@ class Keyword(commands.Bot):
                 client_id=client,
                 nick=channel_name,
                 prefix='!',
-                initial_channels=[channel_name],
+                initial_channels=[f"#channel_name"],
         )
 
         self._keywords = dict()


### PR DESCRIPTION
When you start the bot without putting the "#" before the channel name, the bot continuously throws a key error:

```
ERROR:asyncio:Task exception was never retrieved
  File "C:\Users\mp-pi\Miniconda3\lib\site-packages\twitchio\websocket.py", line 558, in join_action
    cache = self._channel_cache[channel]['channel']._users
KeyError: 'fairfruitbot'
```

Fixed that by adding "#" to the channel name string.